### PR TITLE
fix deprecated fields

### DIFF
--- a/module.json
+++ b/module.json
@@ -4,28 +4,33 @@
   "description": "Adds HP, Structure, Heat, Stress to the combat tracker",
   "version": "This is auto replaced",
   "library": "false",
-  "system": ["lancer"],
   "manifestPlusVersion": "1.0.0",
-  "minimumCoreVersion": "9",
-  "compatibleCoreVersion": "9",
+  "compatibility": {
+    "minimum": "9",
+    "verified": "9"
+  },
   "authors": [
-    {"name":"Aron Morris",
-    "url":"https://github.com/aronmorris"
+    {
+      "name": "Aron Morris",
+      "url": "https://github.com/aronmorris"
     },
     {
       "name": "The League of Extraordinary FVTT Developers",
       "url": "https://github.com/League-of-Foundry-Developers"
     }
   ],
-  "dependencies": [
-    {
-      "name": "lancer",
-      "type": "system"
-    }
-  ],
-  "conflicts": [
-    
-  ],
+  "relationships": {
+    "requires": [
+      {
+        "id": "lancer",
+        "type": "system"
+      }
+    ],
+    "system": [
+      "lancer"
+    ]
+  },
+  "conflicts": [],
   "esmodules": [
     "scripts/module.js"
   ],


### PR DESCRIPTION
Just spotted the warnings locally (10.291) and made the corresponding changes locally to fix it and thought might as well send over a PR. No idea when this was changed and if something else happened, so haven't updated the `compatibleCoreVersion` entry. Test away and change as you wish, just wanted this to be somewhere.